### PR TITLE
License internal JS in a GNU LibreJS way

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -29,6 +29,7 @@
 {{ define "footer" }}
   <!-- If you don't need IE 11 support you can remove this next script block -->
   <script type="text/javascript">
+    // @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3-or-Later
     if (window.navigator.userAgent.indexOf('Trident/') > 0) {
       let urls = [
         {{ "js/libs/iecompat/promises.min.js" | absURL }},
@@ -43,6 +44,7 @@
         head.appendChild(script);
       });
     }
+    // @license-end
   </script>
   <!-- These are the two libraries needed for current browsers. -->
   <script src={{ "js/libs/fuse.js/3.2.1/fuse.min.js" | absURL }}></script>

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -1,4 +1,4 @@
-
+// @license magnet:?xt=urn:btih:1f739d935676111cfff4b4693e3816e664797050&dn=gpl-3.0.txt GPL-v3-or-Later
 // How many characters to include on either side of match keyword
 const summaryInclude=60;
 
@@ -96,3 +96,4 @@ function populateResults(result){
     document.getElementById("search-results").appendChild(frag);
   });
 }
+// @license-end


### PR DESCRIPTION
External JS libraries aren't licensed in a GNU LibreJS way yet. I think that GNU LibreJS should just include those into the list of trusted JS libraries.

The trusted libraries are linked here, but the link seems broken. I can send a mail to inform the FSF about this broken link. https://www.gnu.org/software/librejs/free-your-javascript.html#step2